### PR TITLE
Add Standalone Apple Pay and Google Pay Nonce Support for Flutter Braintree

### DIFF
--- a/android/src/main/java/com/example/flutter_braintree/FlutterBraintreePlugin.java
+++ b/android/src/main/java/com/example/flutter_braintree/FlutterBraintreePlugin.java
@@ -9,6 +9,7 @@ import com.braintreepayments.api.dropin.DropInRequest;
 import com.braintreepayments.api.dropin.DropInResult;
 import com.braintreepayments.api.models.PaymentMethodNonce;
 
+import java.util.ArrayList;
 import java.util.Map;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
@@ -115,6 +116,31 @@ public class FlutterBraintreePlugin implements FlutterPlugin, ActivityAware, Met
       intent.putExtra("payPalPaymentUserAction", (String) request.get("payPalPaymentUserAction"));
       intent.putExtra("billingAgreementDescription", (String) request.get("billingAgreementDescription"));
       activity.startActivityForResult(intent, CUSTOM_ACTIVITY_REQUEST_CODE);
+    } else if (call.method.equals("requestGooglePayNonce")) {
+      String authorization = call.argument("authorization");
+      Intent intent = new Intent(activity, FlutterBraintreeCustom.class);
+      intent.putExtra("type", "requestGooglePayNonce");
+      intent.putExtra("authorization", (String) call.argument("authorization"));
+      assert(call.argument("request") instanceof Map);
+      Map request = (Map) call.argument("request");
+      intent.putExtra("totalPrice", (String) request.get("totalPrice"));
+      intent.putExtra("currencyCode", (String) request.get("currencyCode"));
+      intent.putExtra("billingAddressRequired", (Boolean) request.get("billingAddressRequired"));
+      intent.putExtra("googleMerchantID", (String) request.get("googleMerchantID"));
+      activity.startActivityForResult(intent, CUSTOM_ACTIVITY_REQUEST_CODE);
+    } else if (call.method.equals("requestApplePayNonce")) {
+      String authorization = call.argument("authorization");
+      Intent intent = new Intent(activity, FlutterBraintreeCustom.class);
+      intent.putExtra("type", "requestApplePayNonce");
+      intent.putExtra("authorization", (String) call.argument("authorization"));
+      assert(call.argument("request") instanceof Map);
+      Map request = (Map) call.argument("request");
+      intent.putExtra("displayName", (String) request.get("displayName"));
+      intent.putExtra("currencyCode", (String) request.get("currencyCode"));
+      intent.putExtra("countryCode", (String) request.get("countryCode"));
+      intent.putExtra("merchantIdentifier", (String) request.get("merchantIdentifier"));
+      intent.putStringArrayListExtra("supportedNetworks", (ArrayList<String>) request.get("supportedNetworks"));
+      activity.startActivityForResult(intent, CUSTOM_ACTIVITY_REQUEST_CODE);
     } else {
       result.notImplemented();
       activeResult = null;
@@ -125,7 +151,7 @@ public class FlutterBraintreePlugin implements FlutterPlugin, ActivityAware, Met
   public boolean onActivityResult(int requestCode, int resultCode, Intent data) {
     if (activeResult == null)
       return false;
-    
+
     switch (requestCode) {
       case CUSTOM_ACTIVITY_REQUEST_CODE:
         if (resultCode == Activity.RESULT_OK) {

--- a/ios/Classes/FlutterBraintreeCustomPlugin.swift
+++ b/ios/Classes/FlutterBraintreeCustomPlugin.swift
@@ -2,44 +2,50 @@ import Flutter
 import UIKit
 import Braintree
 import BraintreeDropIn
+import PassKit
 
 public class FlutterBraintreeCustomPlugin: BaseFlutterBraintreePlugin, FlutterPlugin, BTViewControllerPresentingDelegate {
+
+    private var currentFlutterResult: FlutterResult?
+    private var currentAuthorization: String?
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "flutter_braintree.custom", binaryMessenger: registrar.messenger())
-        
+
         let instance = FlutterBraintreeCustomPlugin()
         registrar.addMethodCallDelegate(instance, channel: channel)
     }
-    
+
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         guard !isHandlingResult else {
             returnAlreadyOpenError(result: result)
             return
         }
-        
+
         isHandlingResult = true
-        
+
         guard let authorization = getAuthorization(call: call) else {
             returnAuthorizationMissingError(result: result)
             isHandlingResult = false
             return
         }
-        
+
+        currentAuthorization = authorization
         let client = BTAPIClient(authorization: authorization)
-        
+
         if call.method == "requestPaypalNonce" {
             let driver = BTPayPalDriver(apiClient: client!)
-            
+
             guard let requestInfo = dict(for: "request", in: call) else {
                 isHandlingResult = false
                 return
             }
-            
+
             if let amount = requestInfo["amount"] as? String {
                 let paypalRequest = BTPayPalCheckoutRequest(amount: amount)
                 paypalRequest.currencyCode = requestInfo["currencyCode"] as? String
                 paypalRequest.displayName = requestInfo["displayName"] as? String
-                
+
                 print(requestInfo["isShippingAddressRequired"])
 
                 paypalRequest.isShippingAddressRequired = requestInfo["isShippingAddressRequired"] != nil ? requestInfo["isShippingAddressRequired"]! as! Bool : false
@@ -77,29 +83,141 @@ public class FlutterBraintreeCustomPlugin: BaseFlutterBraintreePlugin, FlutterPl
                     self.isHandlingResult = false
                 }
             }
-            
+
         } else if call.method == "tokenizeCreditCard" {
             let cardClient = BTCardClient(apiClient: client!)
-            
+
             guard let cardRequestInfo = dict(for: "request", in: call) else {return}
-            
+
             let card = BTCard()
             card.number = cardRequestInfo["cardNumber"] as? String
             card.expirationMonth = cardRequestInfo["expirationMonth"] as? String
             card.expirationYear = cardRequestInfo["expirationYear"] as? String
             card.cvv = cardRequestInfo["cvv"] as? String
             card.cardholderName = cardRequestInfo["cardholderName"] as? String
-            
+
             cardClient.tokenizeCard(card) { (nonce, error) in
                 self.handleResult(nonce: nonce, error: error, flutterResult: result)
                 self.isHandlingResult = false
             }
+        } else if call.method == "requestApplePayNonce" {
+            guard let requestInfo = dict(for: "request", in: call) else {
+                isHandlingResult = false
+                return
+            }
+
+            let merchantIdentifier = requestInfo["merchantIdentifier"] as? String ?? ""
+
+            // Get supported networks from request
+            var supportedNetworks: [PKPaymentNetwork] = []
+            if let networks = requestInfo["supportedNetworks"] as? [Int] {
+                supportedNetworks = networks.compactMap { network in
+                    switch network {
+                    case 0: return PKPaymentNetwork.visa
+                    case 1: return PKPaymentNetwork.masterCard
+                    case 2: return PKPaymentNetwork.amex
+                    case 3: return PKPaymentNetwork.discover
+                    default: return nil
+                    }
+                }
+            }
+
+            // Check if Apple Pay is available for this merchant
+            let canMakePayments = PKPaymentAuthorizationController.canMakePayments()
+            let canMakePaymentsWithMerchant = PKPaymentAuthorizationController.canMakePayments(usingNetworks: supportedNetworks)
+
+            if !canMakePayments {
+                result(FlutterError(code: "APPLE_PAY_ERROR",
+                                  message: "Apple Pay is not available on this device. Please check if Apple Pay is set up in your device settings.",
+                                  details: nil))
+                isHandlingResult = false
+                return
+            }
+
+            if !canMakePaymentsWithMerchant {
+                result(FlutterError(code: "APPLE_PAY_ERROR",
+                                  message: "Apple Pay is not available for merchant: \(merchantIdentifier). Please check your Apple Pay configuration in Xcode and Apple Developer account.",
+                                  details: nil))
+                isHandlingResult = false
+                return
+            }
+
+            let paymentRequest = PKPaymentRequest()
+            paymentRequest.merchantIdentifier = merchantIdentifier
+            paymentRequest.countryCode = requestInfo["countryCode"] as? String ?? "US"
+            paymentRequest.currencyCode = requestInfo["currencyCode"] as? String ?? "USD"
+            paymentRequest.supportedNetworks = supportedNetworks
+
+            if let paymentSummaryItems = requestInfo["paymentSummaryItems"] as? [[String: Any]] {
+                paymentRequest.paymentSummaryItems = paymentSummaryItems.compactMap { item in
+                    guard let label = item["label"] as? String,
+                          let amount = item["amount"] as? Double,
+                          let typeRaw = item["type"] as? Int else {
+                        return nil
+                    }
+
+                    let _: PKPaymentSummaryItemType = typeRaw == 0 ? .final : .pending
+                    return PKPaymentSummaryItem(label: label, amount: NSDecimalNumber(value: amount))
+                }
+            }
+
+            // Check if the merchant identifier is valid
+            guard !paymentRequest.merchantIdentifier.isEmpty else {
+                result(FlutterError(code: "APPLE_PAY_ERROR",
+                                  message: "Merchant identifier is required",
+                                  details: nil))
+                isHandlingResult = false
+                return
+            }
+
+            // Check if we have payment summary items
+            guard !paymentRequest.paymentSummaryItems.isEmpty else {
+                result(FlutterError(code: "APPLE_PAY_ERROR",
+                                  message: "At least one payment summary item is required",
+                                  details: nil))
+                isHandlingResult = false
+                return
+            }
+
+            // Add merchant capabilities
+            paymentRequest.merchantCapabilities = .capability3DS
+
+            // Try to initialize the controller
+            guard let applePayController = PKPaymentAuthorizationViewController(paymentRequest: paymentRequest) else {
+                result(FlutterError(code: "APPLE_PAY_ERROR",
+                                  message: "Failed to initialize Apple Pay.",
+                                  details: nil))
+                isHandlingResult = false
+                return
+            }
+
+            // Set the delegate
+            applePayController.delegate = self
+
+            // Present the controller
+            if let rootViewController = UIApplication.shared.keyWindow?.rootViewController {
+                rootViewController.present(applePayController, animated: true) {
+                    print("Apple Pay sheet presented successfully")
+                }
+                self.currentFlutterResult = result
+            } else {
+                result(FlutterError(code: "APPLE_PAY_ERROR",
+                                  message: "No root view controller found to present Apple Pay",
+                                  details: nil))
+                isHandlingResult = false
+            }
+        } else if call.method == "requestGooglePayNonce" {
+            // Google Pay is not available on iOS
+            result(FlutterError(code: "GOOGLE_PAY_ERROR",
+                              message: "Google Pay is not available on iOS devices",
+                              details: nil))
+            isHandlingResult = false
         } else {
             result(FlutterMethodNotImplemented)
             self.isHandlingResult = false
         }
     }
-    
+
     private func handleResult(nonce: BTPaymentMethodNonce?, error: Error?, flutterResult: FlutterResult) {
         if error != nil {
             returnBraintreeError(result: flutterResult, error: error!)
@@ -109,12 +227,47 @@ public class FlutterBraintreeCustomPlugin: BaseFlutterBraintreePlugin, FlutterPl
             flutterResult(buildPaymentNonceDict(nonce: nonce));
         }
     }
-    
+
     public func paymentDriver(_ driver: Any, requestsPresentationOf viewController: UIViewController) {
-        
+
     }
-    
+
     public func paymentDriver(_ driver: Any, requestsDismissalOf viewController: UIViewController) {
-        
+
+    }
+}
+
+extension FlutterBraintreeCustomPlugin: PKPaymentAuthorizationViewControllerDelegate {
+    public func paymentAuthorizationViewController(_ controller: PKPaymentAuthorizationViewController, didAuthorizePayment payment: PKPayment, handler completion: @escaping (PKPaymentAuthorizationResult) -> Void) {
+        guard let authorization = currentAuthorization,
+              let client = BTAPIClient(authorization: authorization) else {
+            completion(PKPaymentAuthorizationResult(status: .failure, errors: nil))
+            return
+        }
+
+        let applePayClient = BTApplePayClient(apiClient: client)
+        applePayClient.tokenizeApplePay(payment) { (nonce, error) in
+            if let error = error {
+                completion(PKPaymentAuthorizationResult(status: .failure, errors: [error]))
+                return
+            }
+
+            if let nonce = nonce {
+                self.handleResult(nonce: nonce, error: nil, flutterResult: self.currentFlutterResult!)
+                completion(PKPaymentAuthorizationResult(status: .success, errors: nil))
+            } else {
+                completion(PKPaymentAuthorizationResult(status: .failure, errors: nil))
+            }
+        }
+    }
+
+    public func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
+        controller.dismiss(animated: true) {
+            if self.currentFlutterResult != nil {
+                self.currentFlutterResult!(nil)
+                self.currentFlutterResult = nil
+            }
+            self.isHandlingResult = false
+        }
     }
 }

--- a/lib/src/custom.dart
+++ b/lib/src/custom.dart
@@ -5,7 +5,7 @@ import 'result.dart';
 
 class Braintree {
   static const MethodChannel _kChannel =
-      const MethodChannel('flutter_braintree.custom');
+  const MethodChannel('flutter_braintree.custom');
 
   const Braintree._();
 
@@ -16,9 +16,9 @@ class Braintree {
   ///
   /// Returns a [Future] that resolves to a [BraintreePaymentMethodNonce] if the tokenization was successful.
   static Future<BraintreePaymentMethodNonce?> tokenizeCreditCard(
-    String authorization,
-    BraintreeCreditCardRequest request,
-  ) async {
+      String authorization,
+      BraintreeCreditCardRequest request,
+      ) async {
     final result = await _kChannel.invokeMethod('tokenizeCreditCard', {
       'authorization': authorization,
       'request': request.toJson(),
@@ -35,12 +35,50 @@ class Braintree {
   /// Returns a [Future] that resolves to a [BraintreePaymentMethodNonce] if the user confirmed the request,
   /// or `null` if the user canceled the Vault or Checkout flow.
   static Future<BraintreePaymentMethodNonce?> requestPaypalNonce(
-    String authorization,
-    BraintreePayPalRequest request,
-  ) async {
+      String authorization,
+      BraintreePayPalRequest request,
+      ) async {
     print("PAYPAL REQUEST");
     print( request.toJson());
     final result = await _kChannel.invokeMethod('requestPaypalNonce', {
+      'authorization': authorization,
+      'request': request.toJson(),
+    });
+    if (result == null) return null;
+    return BraintreePaymentMethodNonce.fromJson(result);
+  }
+
+  /// Requests a Google Pay payment method nonce directly without the drop-in UI.
+  ///
+  /// [authorization] must be either a valid client token or a valid tokenization key.
+  /// [request] should contain all the information necessary for the Google Pay request.
+  ///
+  /// Returns a [Future] that resolves to a [BraintreePaymentMethodNonce] if the user confirmed the request,
+  /// or `null` if the user canceled the payment flow.
+  static Future<BraintreePaymentMethodNonce?> requestGooglePayNonce(
+      String authorization,
+      BraintreeGooglePaymentRequest request,
+      ) async {
+    final result = await _kChannel.invokeMethod('requestGooglePayNonce', {
+      'authorization': authorization,
+      'request': request.toJson(),
+    });
+    if (result == null) return null;
+    return BraintreePaymentMethodNonce.fromJson(result);
+  }
+
+  /// Requests an Apple Pay payment method nonce directly without the drop-in UI.
+  ///
+  /// [authorization] must be either a valid client token or a valid tokenization key.
+  /// [request] should contain all the information necessary for the Apple Pay request.
+  ///
+  /// Returns a [Future] that resolves to a [BraintreePaymentMethodNonce] if the user confirmed the request,
+  /// or `null` if the user canceled the payment flow.
+  static Future<BraintreePaymentMethodNonce?> requestApplePayNonce(
+      String authorization,
+      BraintreeApplePayRequest request,
+      ) async {
+    final result = await _kChannel.invokeMethod('requestApplePayNonce', {
       'authorization': authorization,
       'request': request.toJson(),
     });


### PR DESCRIPTION
### Summary

This PR introduces support for retrieving nonces for Apple Pay and Google Pay as standalone payment methods, without requiring the Braintree Drop-in UI. 

This enhancement aligns with the existing `requestPaypalNonce` method and provides a more seamless and customizable checkout experience, especially for apps with dedicated Apple Pay or Google Pay buttons.

### Key Changes

- ➕ Added new methods:
  - `requestApplePayNonce()`
  - `requestGooglePayNonce()`

- 🛠️ Platform-specific implementation:
  - **iOS**: Integrated native Apple Pay logic to handle tokenization and return nonce.
  - **Android**: Added support for Google Pay tokenization and nonce generation using Braintree SDK.
  
- 🧪 Fully tested on real devices for both platforms to ensure smooth payment flow and consistent nonce generation.

### Motivation

The current Drop-in UI presents a bottom sheet where users must choose a payment method again, even if the app already displays dedicated Apple Pay or Google Pay buttons. This PR solves that by allowing developers to bypass the Drop-in and directly initiate Apple/Google Pay flows, improving UX and aligning with modern payment design patterns.

### Backward Compatibility

✅ Fully backward compatible – existing Drop-in and payment methods remain unchanged.
